### PR TITLE
Complete issue #2: define data models for structured extraction results

### DIFF
--- a/clinical_text_parser/models/extraction.py
+++ b/clinical_text_parser/models/extraction.py
@@ -1,13 +1,14 @@
-"""Structured result models for extracted clinical text information."""
+"""Data models for structured clinical text extraction output."""
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from typing import Any
+from dataclasses import dataclass, field
 
 
 @dataclass
 class SymptomMention:
+    """Structured representation of a single symptom mention."""
+
     symptom: str
     matched_text: str
     severity: str | None = None
@@ -15,19 +16,32 @@ class SymptomMention:
     body_location: str | None = None
     negated: bool = False
     associated_symptoms: list[str] = field(default_factory=list)
-    evidence: str | None = None
+    evidence: str = ""
 
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+    def to_dict(self) -> dict[str, object]:
+        """Convert the symptom mention to a JSON-serializable dictionary."""
+        return {
+            "symptom": self.symptom,
+            "matched_text": self.matched_text,
+            "severity": self.severity,
+            "duration": self.duration,
+            "body_location": self.body_location,
+            "negated": self.negated,
+            "associated_symptoms": self.associated_symptoms,
+            "evidence": self.evidence,
+        }
 
 
 @dataclass
 class ParsedClinicalText:
+    """Structured parser output for a full clinical text snippet."""
+
     text: str
     normalized_text: str
     mentions: list[SymptomMention] = field(default_factory=list)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, object]:
+        """Convert the parsed result to a JSON-serializable dictionary."""
         return {
             "text": self.text,
             "normalized_text": self.normalized_text,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,56 @@
+from clinical_text_parser.models import ParsedClinicalText, SymptomMention
+
+
+def test_symptom_mention_to_dict() -> None:
+    mention = SymptomMention(
+        symptom="chest pain",
+        matched_text="chest pain",
+        severity="severe",
+        duration="2 days",
+        body_location="chest",
+        negated=False,
+        associated_symptoms=["shortness of breath"],
+        evidence="patient has had severe chest pain for 2 days",
+    )
+
+    assert mention.to_dict() == {
+        "symptom": "chest pain",
+        "matched_text": "chest pain",
+        "severity": "severe",
+        "duration": "2 days",
+        "body_location": "chest",
+        "negated": False,
+        "associated_symptoms": ["shortness of breath"],
+        "evidence": "patient has had severe chest pain for 2 days",
+    }
+
+
+def test_parsed_clinical_text_to_dict() -> None:
+    result = ParsedClinicalText(
+        text="Patient has chest pain.",
+        normalized_text="patient has chest pain.",
+        mentions=[
+            SymptomMention(
+                symptom="chest pain",
+                matched_text="chest pain",
+                evidence="patient has chest pain",
+            )
+        ],
+    )
+
+    assert result.to_dict() == {
+        "text": "Patient has chest pain.",
+        "normalized_text": "patient has chest pain.",
+        "mentions": [
+            {
+                "symptom": "chest pain",
+                "matched_text": "chest pain",
+                "severity": None,
+                "duration": None,
+                "body_location": None,
+                "negated": False,
+                "associated_symptoms": [],
+                "evidence": "patient has chest pain",
+            }
+        ],
+    }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from clinical_text_parser import ClinicalTextParser, parse_clinical_text
+from clinical_text_parser.parser import ClinicalTextParser, parse_clinical_text
 
 
 def test_extracts_symptom_severity_duration_and_association() -> None:


### PR DESCRIPTION
This PR completes issue #2 by adding the core structured output models for the parser.

Included in this PR

- `SymptomMention` dataclass
- `ParsedClinicalText` dataclass
- `to_dict()` serialization methods
- model export updates in `clinical_text_parser/models/__init__.py`
- unit tests for model serialization

Validation

```bash
python -m pytest